### PR TITLE
Fixed: Missing Searchable plugin name

### DIFF
--- a/Console/Command/Task/IndexTask.php
+++ b/Console/Command/Task/IndexTask.php
@@ -1,6 +1,6 @@
 <?php
 class IndexTask extends Shell {
-    public $uses = array('SearchIndex');
+    public $uses = array('Searchable.SearchIndex');
     public $tasks = array('DbConfig', 'Model', 'Searchable.ProgressBar');
     public $modelCache = array();
 


### PR DESCRIPTION
Loading wrong model from AppModel instead SearchIndex plugin Model