### PR TITLE
New relevance field for natural language searches

### DIFF
--- a/Console/Command/Task/IndexTask.php
+++ b/Console/Command/Task/IndexTask.php
@@ -1,6 +1,6 @@
 <?php
 class IndexTask extends Shell {
-    public $uses = array('SearchIndex');
+    public $uses = array('Searchable.SearchIndex');
     public $tasks = array('DbConfig', 'Model', 'Searchable.ProgressBar');
     public $modelCache = array();
 

--- a/Model/Behavior/SearchableBehavior.php
+++ b/Model/Behavior/SearchableBehavior.php
@@ -118,6 +118,8 @@ class SearchableBehavior extends ModelBehavior {
         }
 
         $index = join('. ',$index);
+        // Some servers have issues with locale settings, we must set to the cake locale language before calling iconv.
+        setlocale(LC_ALL, Configure::read('Config.language'));
         $index = iconv('UTF-8', 'ASCII//TRANSLIT', $index);
         $index = preg_replace('/[\ ]+/',' ',$index);
         $index = $this->removeStopwords($index);

--- a/Model/Behavior/SearchableBehavior.php
+++ b/Model/Behavior/SearchableBehavior.php
@@ -32,7 +32,7 @@ class SearchableBehavior extends ModelBehavior {
         }
         $this->stopwords = $stopwords;
     }
-    
+
     private function processData(Model $Model) {
         if (method_exists($Model, 'indexData')) {
             return $Model->indexData();
@@ -40,7 +40,7 @@ class SearchableBehavior extends ModelBehavior {
             return $this->index($Model);
         }
     }
-    
+
     public function beforeSave(Model $Model, $options = array()) {
         if ($Model->id) {
             $this->settings[$Model->alias]['foreignKey'] = $Model->id;
@@ -52,7 +52,7 @@ class SearchableBehavior extends ModelBehavior {
         }
         return true;
     }
-    
+
     public function afterSave(Model $Model, $created, $options = array()) {
         if ($this->settings[$Model->alias]['_index'] !== false) {
             if (!$this->SearchIndex) {
@@ -85,14 +85,14 @@ class SearchableBehavior extends ModelBehavior {
                             'data' => $this->settings[$Model->alias]['_index']
                         )
                     )
-                );              
+                );
             }
             $this->settings[$Model->alias]['_index'] = false;
             $this->settings[$Model->alias]['foreignKey'] = false;
         }
         return true;
     }
-    
+
     private function index(Model $Model) {
         $index = array();
         $data = $Model->data[$Model->alias];
@@ -156,7 +156,7 @@ class SearchableBehavior extends ModelBehavior {
         $findOptions['conditions'] = array_merge(
             $findOptions['conditions'], array("MATCH(SearchIndex.data) AGAINST('$q' IN BOOLEAN MODE)")
         );
-        return $this->SearchIndex->find('all', $findOptions);       
+        return $this->SearchIndex->find('all', $findOptions);
     }
-    
+
 }

--- a/Model/Behavior/SearchableBehavior.php
+++ b/Model/Behavior/SearchableBehavior.php
@@ -60,6 +60,7 @@ class SearchableBehavior extends ModelBehavior {
             }
             if ($this->settings[$Model->alias]['foreignKey'] == 0) {
                 $this->settings[$Model->alias]['foreignKey'] = $Model->getLastInsertID();
+                $this->SearchIndex->create();
                 $this->SearchIndex->save(
                     array(
                         'SearchIndex' => array(

--- a/Model/Behavior/SearchableBehavior.php
+++ b/Model/Behavior/SearchableBehavior.php
@@ -13,7 +13,7 @@ class SearchableBehavior extends ModelBehavior {
     public $model;
 
     public function setup(Model $Model, $config = array()) {
-        $this->settings[$Model->alias] = array_merge($this->__defaultSettings, $config);
+        $this->settings[$Model->name] = array_merge($this->__defaultSettings, $config);
         $this->model =& $Model;
 
         Configure::load('Searchable.stopwords');

--- a/Model/SearchIndex.php
+++ b/Model/SearchIndex.php
@@ -4,6 +4,9 @@ class SearchIndex extends SearchableAppModel {
     public $useTable = 'search_indices';
     private $models = array();
     public $recursive = 1;
+    public $virtualFields = array(
+        'relevance' => null
+    );
 
     private function bindTo($model) {
         $this->bindModel( 
@@ -50,6 +53,24 @@ class SearchIndex extends SearchableAppModel {
                 $queryData['conditions'][] = array('OR' => $models_condition);
             }
         }
+
+        // Add relevance field
+        if (is_string($queryData['conditions'])) {
+            //Remove any other from the conditions just to calculate relevance
+            $conditions = explode(' AND ', $queryData['conditions']);
+            $this->virtualFields['relevance'] = $conditions[0];
+        } else {
+            foreach ($queryData['conditions'] as $condition) {
+                foreach ($condition as $operator => $values) {
+                    if (!empty($this->virtualFields['relevance'])) {
+                        $this->virtualFields['relevance'] .= ' AND (' . implode(" $operator ", $values) . ')';
+                    } else {
+                        $this->virtualFields['relevance'] = implode(" $operator ", $values);
+                    }
+                }
+            }
+        }
+
         return $queryData;  
     }
 

--- a/Model/SearchIndex.php
+++ b/Model/SearchIndex.php
@@ -60,15 +60,8 @@ class SearchIndex extends SearchableAppModel {
             $conditions = explode(' AND ', $queryData['conditions']);
             $this->virtualFields['relevance'] = $conditions[0];
         } else {
-            foreach ($queryData['conditions'] as $condition) {
-                foreach ($condition as $operator => $values) {
-                    if (!empty($this->virtualFields['relevance'])) {
-                        $this->virtualFields['relevance'] .= ' AND (' . implode(" $operator ", $values) . ')';
-                    } else {
-                        $this->virtualFields['relevance'] = implode(" $operator ", $values);
-                    }
-                }
-            }
+            // Do nothing, set relevance to 1
+            $this->virtualFields['relevance'] = 1;
         }
 
         return $queryData;  

--- a/README.md
+++ b/README.md
@@ -72,7 +72,20 @@ At your disposal, there are several ways to use it:
 
 You can use the SearchIndex model to do the searches using the regular cake php ** Model->find() **. By default this will search all the subjects (if you have more than one searchable model). To search only ceratin models you can use **SearchIndex->searchModels()** 
 
-An example usage, using cakephp pagination: 
+An example usage, using cakephp pagination, natural language search and relevance ordering:
+    <?php
+    	$this->SearchIndex->searchModels(array('Post','Comment'));
+    	$this->paginate = array(
+    		'limit' => 10,
+    		'conditions' =>  "MATCH(SearchIndex.data) AGAINST('$q' IN BOOLEAN MODE)",
+            'order' => array(
+                'relevance' => 'desc'
+            )
+    	);
+    	$this->set('results', $this->paginate('SearchIndex'));
+    ?>
+    
+An example usage, using cakephp pagination and boolean search: 
 
     <?php
     	$this->SearchIndex->searchModels(array('Post','Comment'));
@@ -82,6 +95,7 @@ An example usage, using cakephp pagination:
     	);
     	$this->set('results', $this->paginate('SearchIndex'));
     ?>
+In a boolean search you cannot order by relevance (relevance field is always 1)
 
 ### The searchable model
 

--- a/Test/Case/Model/Behavior/SearchableBehaviorTest.php
+++ b/Test/Case/Model/Behavior/SearchableBehaviorTest.php
@@ -16,7 +16,8 @@ class SearchableBehaviorTest extends CakeTestCase {
     public $fixtures = array(
         'plugin.searchable.search_index',
         'core.author',
-        'core.post'
+        'core.post',
+        'core.apple'
     );
 
     /**
@@ -140,7 +141,7 @@ class SearchableBehaviorTest extends CakeTestCase {
 
         // Check if the process deleted the associated SearchIndex
         $result = $this->SearchIndex->find('first', array(
-            'conditions' => array('association_key' => 1)
+            'conditions' => array('model' => 'Author', 'association_key' => 1)
         ));
         $this->assertEqual('0', sizeof($result));
     }

--- a/Test/Case/Model/SearchIndexTest.php
+++ b/Test/Case/Model/SearchIndexTest.php
@@ -16,8 +16,8 @@ class SearchIndexTest extends CakeTestCase {
     */
     public $fixtures = array(
         'plugin.searchable.search_index',
+        'core.apple',
         'core.author',
-        'core.article'
     );
 
 
@@ -32,6 +32,8 @@ class SearchIndexTest extends CakeTestCase {
         $this->SearchIndex = ClassRegistry::init('Searchable.SearchIndex');
         $this->Author = ClassRegistry::init('Author');
         $this->Author->Behaviors->load('Searchable.Searchable');
+        $this->Apple = ClassRegistry::init('Apple');
+        $this->Apple->Behaviors->load('Searchable.Searchable');
     }
 
     public function testFind1()
@@ -47,12 +49,24 @@ class SearchIndexTest extends CakeTestCase {
     public function testFind2()
     {
         // Test 2
-        $this->SearchIndex->searchModels(array('Author', 'Article'));
+        $this->SearchIndex->searchModels(array('Author', 'Apple'));
         $result = $this->SearchIndex->find('all', array(
-            'conditions' => "MATCH(SearchIndex.data) AGAINST('nate' IN BOOLEAN MODE)"
+            'conditions' => "MATCH(SearchIndex.data) AGAINST('red apple')",
+            'order' => array(
+                'relevance' => 'desc'
+            )
         ));
-        $error = print_r($result, true);
-        $this->assertEqual(1, sizeof($result), $error);
+        $expected = array(
+            'id' => 5,
+            'association_key' => 1,
+            'model' => 'Apple',
+            'data' => 'Red 1.Red Apple 1',
+            'created' => '2015-08-26',
+            'modified' => '2015-08-26',
+            'relevance' => '0.8376647233963013',
+            'displayField' => 'name'
+        );
+        $this->assertEqual($expected, Hash::get($result, '0.SearchIndex'));
     }
 
     public function testFind3()

--- a/Test/Fixture/SearchIndexFixture.php
+++ b/Test/Fixture/SearchIndexFixture.php
@@ -53,10 +53,6 @@ class SearchIndexFixture extends CakeTestFixture {
             'association_key' => array(
                 'column' => array('association_key', 'model'),
                 'unique' => 0
-            ),
-            'data' => array(
-                'column' => 'data',
-                'unique' => 0
             )
         ),
         'tableParameters' => array(
@@ -97,8 +93,76 @@ class SearchIndexFixture extends CakeTestFixture {
                 'created' => '2015-08-26',
                 'modified' => '2015-08-26'
             ),
+            array(
+                'association_key' => 1,
+                'model' => 'Apple',
+                'data' => 'Red 1.Red Apple 1',
+                'created' => '2015-08-26',
+                'modified' => '2015-08-26'
+            ),
+            array(
+                'association_key' => 2,
+                'model' => 'Apple',
+                'data' => 'Bright Red 1.Bright Red Apple',
+                'created' => '2015-08-26',
+                'modified' => '2015-08-26'
+            ),
+            array(
+                'association_key' => 3,
+                'model' => 'Apple',
+                'data' => 'blue green.green blue',
+                'created' => '2015-08-26',
+                'modified' => '2015-08-26'
+            ),
+            array(
+                'association_key' => 4,
+                'model' => 'Apple',
+                'data' => 'Blue Green.Test Name',
+                'created' => '2015-08-26',
+                'modified' => '2015-08-26'
+            ),
+            array(
+                'association_key' => 5,
+                'model' => 'Apple',
+                'data' => 'Green.Blue Green',
+                'created' => '2015-08-26',
+                'modified' => '2015-08-26'
+            ),
+            array(
+                'association_key' => 6,
+                'model' => 'Apple',
+                'data' => 'My new appleOrange.My new apple',
+                'created' => '2015-08-26',
+                'modified' => '2015-08-26'
+            ),
         );
         parent::init();
+    }
+
+    public function create($db)
+    {
+        $ok = parent::create($db);
+
+        // Workaround: CakeSchema cannot create FULLTEXT fixtures, so we change the table manually after creation
+        if($ok) {
+            $query = "ALTER TABLE `{$this->table}` ADD FULLTEXT INDEX `data` (`data` ASC)";
+            try {
+                $db->rawQuery($query);
+                $this->created[] = $db->configKeyName;
+            } catch (Exception $e) {
+                $msg = __d(
+                    'cake_dev',
+                    'Fixture creation for "%s" failed "%s"',
+                    $this->table,
+                    $e->getMessage()
+                );
+                CakeLog::error($msg);
+                trigger_error($msg, E_USER_WARNING);
+                return false;
+            }
+            return true;
+        }
+        return false;
     }
 
 }


### PR DESCRIPTION
With the natural language search (https://dev.mysql.com/doc/refman/5.0/en/fulltext-natural-language.html) We can set a field to order by relevance, I changed the code to create a virtual field named relevance, so users now can use the order option in pagination with this field.